### PR TITLE
Visit and component indexing for (de)serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,34 +39,6 @@ if(auto values = helper.get_if<Health, std::string>(cat))
 }
 ```
 
-### Visit components of an entity and serialization
-
-Sometimes, you need to do an operation on many components of an entity in a generic way, for example for serialization.
-
-You may do this by visiting the entity on selected components in a type-safe manner. The types of components the entity doesn't have will be ignored.
-
-```cpp
-struct Position
-{
-    float x, y;
-
-    void serialize() {};
-};
-
-struct Health
-{
-    float x, y;
-
-    void serialize() {};
-};
-
-helper.visit<Position, Health>(cat, [](auto component)
-{
-    component.serialize();
-    // this is safe, compilation will fail if all the components don't have the "serialize" member
-});
-```
-
 ### Iterate over entities
 
 You will for sure want to retrieve all the entities containing one or more components. To do so, you can create a View which will be automatically, or not, updated by the helper.
@@ -86,9 +58,54 @@ for(auto [entity, position]: view.each())
 }
 ```
 
+### Visit components, (de)serialization
+
+Sometimes, you need to do an operation on many components of an entity in a generic way, for example to serialize it.
+
+You may do this by visiting the entity on selected components in a type-safe manner. The component types that the entity doesn't have will be ignored.
+
+**Index components**
+```cpp
+struct Position
+{
+    float x, y;
+
+    std::string serialize() {};
+    void deserialize(std::string data) {};
+};
+
+struct Health
+{
+    float x, y;
+
+    std::string serialize() {};
+    void deserialize(std::string data) {};
+};
+
+helper.index<Position, Health>("position", "health"); // associate an unique ID to components for (de)serialization
+```
+
+**Serialization**
+```cpp
+helper.visit<Position, Health>(cat, [](auto component, auto index)
+{
+    auto data = component.serialize(); // save data and index to a file
+});
+```
+
+**Deserialization**
+```cpp
+std::string index, data; // load data and index from a file
+
+helper.visit<Position, Health>(cat, index, [&data](auto component)
+{
+    component.deserialize(data);
+});
+```
+
 ### Full example
 
-Checkout the following example code, which can also be found inside the `examples/getting-started` folder, to get an overview of most features.
+Checkout the following example codes, which can also be found inside the `examples` folder, to get an overview of most features.
 
 Ofcourse, you will be able to make more complex programs (e.g, creating classes for your systems).
-CNtity's best point is that it isn't imposing any architecture to your application.
+CNtity's best point is that it isn't forcing some "architecture" on your application.

--- a/examples/getting-started/main.cpp
+++ b/examples/getting-started/main.cpp
@@ -43,7 +43,7 @@ int main()
     helper.add<std::string>(clone, "clone de chat");
 
     // Visit components of an entity
-    helper.visit<Position, Health>(chat, [](auto component)
+    helper.visit<Position, Health>(chat, [](auto component, auto index)
     {
         component.to_string();
     });

--- a/examples/serialization/main.cpp
+++ b/examples/serialization/main.cpp
@@ -1,0 +1,105 @@
+// CNtity
+#include "CNtity/Helper.hpp"
+
+#include <iostream>
+#include <map>
+
+////////////////////////////////////////////////////////////
+struct Position
+{
+    float x, y;
+
+    std::string to_string()
+    {
+        return std::to_string(x) + " " + std::to_string(y);
+    }
+
+    void from_string(std::string string)
+    {
+        std::stringstream ss(string);
+        ss >> string;
+        x = std::stof(string);
+        ss >> string;
+        y = std::stof(string);
+    }
+};
+
+////////////////////////////////////////////////////////////
+struct Health
+{
+    int max, current;
+
+    std::string to_string()
+    {
+        return std::to_string(max) + " " + std::to_string(current);
+    }
+
+    void from_string(std::string string)
+    {
+        std::stringstream ss(string);
+        ss >> string;
+        max = std::stoi(string);
+        ss >> string;
+        current = std::stoi(string);
+    }
+};
+
+////////////////////////////////////////////////////////////
+std::vector<std::pair<std::string, std::string>> serialize(CNtity::Helper& helper, const CNtity::Entity& entity)
+{
+    std::vector<std::pair<std::string, std::string>> components;
+
+    helper.visit<Position, Health>(entity, [&helper, &components](auto component, auto index)
+    {
+        if(index)
+        {
+            components.push_back(std::make_pair(index.value(), component.to_string()));
+        }
+    });
+
+    return components;
+}
+
+////////////////////////////////////////////////////////////
+CNtity::Entity deserialize(CNtity::Helper& helper, const std::vector<std::pair<std::string, std::string>>& components)
+{
+    auto entity = helper.create();
+
+    for(auto [index, data]: components)
+    {
+        helper.visit<Position, Health>(entity, index, [&data](auto& component)
+        {
+            component.from_string(data);
+        });
+    }
+
+    return entity;
+}
+
+////////////////////////////////////////////////////////////
+int main()
+{
+    CNtity::Helper helper;
+    helper.index<Position>("position");
+
+    auto entity = helper.create<Position, Health>({5.2, 10.3}, {80, 100});
+
+    auto components = serialize(helper, entity);
+
+    helper.remove(entity);
+
+    // [...] write to file, load from file
+
+    entity = deserialize(helper, components);
+
+    if(auto tuple = helper.get_if<Position, Health>(entity))
+    {
+        std::apply([](auto&&... args)
+        {
+            ((std::cout << args.to_string() << std::endl), ...);
+        },
+                   *tuple);
+    }
+
+    return 0;
+}

--- a/examples/serialization/main.cpp
+++ b/examples/serialization/main.cpp
@@ -80,7 +80,7 @@ CNtity::Entity deserialize(CNtity::Helper& helper, const std::vector<std::pair<s
 int main()
 {
     CNtity::Helper helper;
-    helper.index<Position>("position");
+    helper.index<Position, Health>("position", "health");
 
     auto entity = helper.create<Position, Health>({5.2, 10.3}, {80, 100});
 
@@ -94,11 +94,11 @@ int main()
 
     if(auto tuple = helper.get_if<Position, Health>(entity))
     {
+        // print in a generic way
         std::apply([](auto&&... args)
         {
             ((std::cout << args.to_string() << std::endl), ...);
-        },
-                   *tuple);
+        }, *tuple);
     }
 
     return 0;


### PR DESCRIPTION
Instead of using the name() member of typeinfo, one can now bind a string to a component type which can be stored at serialization and reused at deserialization to know the type of the component getting deserialized.

Added index member to add indexes to component types
Adapted visit functions to give and use the index

